### PR TITLE
First working interstate

### DIFF
--- a/examples/traffic_light/cycle.rb
+++ b/examples/traffic_light/cycle.rb
@@ -1,0 +1,7 @@
+class Cycle
+  include Interactor
+
+  def call
+    puts 'changing the state of TrafficLight'
+  end
+end

--- a/examples/traffic_light/traffic_light.rb
+++ b/examples/traffic_light/traffic_light.rb
@@ -1,0 +1,16 @@
+require 'interstate'
+require_relative 'cycle'
+
+class TrafficLight
+  include Interstate
+
+  initial_state :stop
+
+  transition_table :stop, :proceed, :caution do
+    on event: :cycle do |event|
+      allow event: event, transition_to: [:proceed], from: [:stop]
+      allow event: event, transition_to: [:caution], from: [:proceed]
+      allow event: event, transition_to: [:stop], from: [:caution]
+    end
+  end
+end


### PR DESCRIPTION
This add the first working interstate. It doesn't have many commits because I've just added spec and some changes to a previous experiment.

Here a little demo:
```
class TrafficLight
  include Interstate

  initial_state :stop

  transition_table :stop, :proceed, :caution do
    on event: :cycle do |event|
      allow event: event, transition_to: [:proceed], from: [:stop]
      allow event: event, transition_to: [:caution], from: [:proceed]
      allow event: event, transition_to: [:stop], from: [:caution]
    end
  end
end
```
This is the class which we want to add a basic state machine.

```
class Cycle
  include Interactor

  def call
     # run some logic and if successful the transition can happen
  end
end
```
This is an interactor representing the event that TrafficLight receive in order to have a transition

```
t = TrafficLight.new
t.cycle
> changing the state of TrafficLight
t.state
> :proceed
t.cycle
> changing the state of TrafficLight
t.state
> :caution
t.cycle
> changing the state of TrafficLight
t.state
> :stop
t.states
> [:stop, :proceed, :caution]
```
It's a really simple state machine, the difference is that when transitioning, an interactor which class is named like the event, is called to process logic and validate the transition. 
A simple state machine with the easy and solid interactor pattern
Currently the only dependency is the Interactor gem