### PR TITLE
Fix a case where unallowed transition didn't raise anything

### DIFF
--- a/examples/vehicle/crash.rb
+++ b/examples/vehicle/crash.rb
@@ -1,0 +1,7 @@
+class Crash
+  include Interactor
+
+  def call
+    puts "changing the state after #{self.class} event"
+  end
+end

--- a/examples/vehicle/idle.rb
+++ b/examples/vehicle/idle.rb
@@ -1,0 +1,7 @@
+class Idle
+  include Interactor
+
+  def call
+    puts "changing the state after #{self.class} event"
+  end
+end

--- a/examples/vehicle/ignite.rb
+++ b/examples/vehicle/ignite.rb
@@ -1,0 +1,7 @@
+class Ignite
+  include Interactor
+
+  def call
+    puts "changing the state after #{self.class} event"
+  end
+end

--- a/examples/vehicle/park.rb
+++ b/examples/vehicle/park.rb
@@ -1,0 +1,7 @@
+class Park
+  include Interactor
+
+  def call
+    puts "changing the state after #{self.class} event"
+  end
+end

--- a/examples/vehicle/repair.rb
+++ b/examples/vehicle/repair.rb
@@ -1,0 +1,7 @@
+class Repair
+  include Interactor
+
+  def call
+    puts "changing the state after #{self.class} event"
+  end
+end

--- a/examples/vehicle/shift_down.rb
+++ b/examples/vehicle/shift_down.rb
@@ -1,0 +1,7 @@
+class ShiftDown
+  include Interactor
+
+  def call
+    puts "changing the state after #{self.class} event"
+  end
+end

--- a/examples/vehicle/shift_up.rb
+++ b/examples/vehicle/shift_up.rb
@@ -1,0 +1,7 @@
+class ShiftUp
+  include Interactor
+
+  def call
+    puts "changing the state after #{self.class} event"
+  end
+end

--- a/examples/vehicle/vehicle.rb
+++ b/examples/vehicle/vehicle.rb
@@ -1,0 +1,32 @@
+require 'interstate'
+require_relative 'shift_up'
+require_relative 'shift_down'
+require_relative 'repair'
+require_relative 'park'
+require_relative 'ignite'
+require_relative 'idle'
+require_relative 'crash'
+
+
+class Vehicle
+  include Interstate
+
+  initial_state :parked
+
+  transition_table :parked, :idling, :first_gear, :second_gear, :third_gear, :stalled do
+    on event: :park, transition_to: [:parked], from: [:idling, :first_gear]
+    on event: :ignite, transition_to: [:idling], from: [:parked]
+    on event: :idle, transition_to: [:idling], from: [:first_gear]
+    on event: :shift_up do |event|
+      allow event: event, transition_to: [:first_gear], from: [:idling]
+      allow event: event, transition_to: [:second_gear], from: [:first_gear]
+      allow event: event, transition_to: [:third_gear], from: [:second_gear]
+    end
+    on event: :shift_down do |event|
+      allow event: event, transition_to: [:second_gear], from: [:third_gear]
+      allow event: event, transition_to: [:first_gear], from: [:second_gear]
+    end
+    on event: :crash, transition_to: [:stalled], from: [:first_gear, :second_gear, :third_gear]
+    on event: :repair, transition_to: [:parked], from: [:stalled]
+  end
+end

--- a/lib/interstate.rb
+++ b/lib/interstate.rb
@@ -1,7 +1,6 @@
 require "interstate/version"
 require "interstate/state_machine"
 require 'interactor'
-
 module Interstate
   def self.included(base)
     base.class_eval do
@@ -34,7 +33,7 @@ module Interstate
       if block_given?
         yield(event)
         define_method event do
-          send "#{event}_#{state}"
+          respond_to?("#{event}_#{state}") ? send("#{event}_#{state}") : raise
           action = Object.const_get(event.to_s.split('_').collect(&:capitalize).join).call(base_object: self)
           if action.success?
             @state_machine.next

--- a/spec/examples/vehicle/vehicle_spec.rb
+++ b/spec/examples/vehicle/vehicle_spec.rb
@@ -1,0 +1,54 @@
+require "spec_helper"
+
+RSpec.describe Vehicle do
+  let(:vehicle) { described_class.new }
+  before do
+    expect(vehicle.state).to eq :parked
+  end
+
+  it "can properly run throught all the states" do
+    vehicle.ignite
+    expect(vehicle.state).to eq :idling
+
+    vehicle.shift_up
+    expect(vehicle.state).to eq :first_gear
+
+    vehicle.shift_up
+    expect(vehicle.state).to eq :second_gear
+
+    vehicle.shift_up
+    expect(vehicle.state).to eq :third_gear
+
+    vehicle.shift_down
+    expect(vehicle.state).to eq :second_gear
+
+    vehicle.shift_down
+    expect(vehicle.state).to eq :first_gear
+
+    vehicle.crash
+    expect(vehicle.state).to eq :stalled
+
+    vehicle.repair
+    expect(vehicle.state).to eq :parked
+
+    vehicle.ignite
+    expect(vehicle.state).to eq :idling
+
+    vehicle.shift_up
+    expect(vehicle.state).to eq :first_gear
+
+    vehicle.idle
+    expect(vehicle.state).to eq :idling
+  end
+
+  it 'returns error when transition rule is not respected' do
+    expect{vehicle.crash}.to raise_error RuntimeError
+    expect(vehicle.state).to eq :parked
+  end
+
+  context 'when event has multiple transition and is called in wrong state' do
+    it 'returns error' do
+      expect{vehicle.shift_down}.to raise_error RuntimeError
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,4 +2,6 @@ require "simplecov"
 SimpleCov.start
 require 'bundler/setup'
 require 'interstate'
-require 'byebug'
+require_relative '../examples/vehicle/vehicle.rb'
+
+Dir[File.join(File.dirname(__FILE__), '/examples/**/*.rb')].each { |f| require f }


### PR DESCRIPTION
Raise an error when attempting to transition with a event which has a block. Also add Vehicle example