### PR TITLE
Event with multiple transition interactors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /pkg/
 /spec/reports/
 /tmp/
+/examples/
 
 # rspec failure tracking
 .rspec_status

--- a/examples/traffic_light/cycle.rb
+++ b/examples/traffic_light/cycle.rb
@@ -1,7 +1,0 @@
-class Cycle
-  include Interactor
-
-  def call
-    puts 'changing the state of TrafficLight'
-  end
-end

--- a/examples/traffic_light/traffic_light.rb
+++ b/examples/traffic_light/traffic_light.rb
@@ -1,8 +1,10 @@
 require 'interstate'
-require_relative 'cycle'
-
+require_relative 'cycle_proceed'
+require 'byebug'
 class TrafficLight
   include Interstate
+
+  attr_accessor :state
 
   initial_state :stop
 

--- a/lib/interstate.rb
+++ b/lib/interstate.rb
@@ -47,7 +47,7 @@ module Interstate
 
     def allow(event: nil, transition_to: nil, from: nil)
       define_method "#{event}_#{from.first}" do
-        ensure_can_transit(event, transition_to, from)
+        ensure_can_transit(event, transition_to, from, multiple: true)
       end
     end
 
@@ -56,7 +56,7 @@ module Interstate
     def perform_transition_by(event: nil, transition_to: nil, from: nil)
       define_method event do
         evaluate_transition(event, transition_to, from)
-        action = constantize(event).call(object: self)
+        action = constantize(interactor_name(event)).call(object: self)
         action.success? ? @state_machine.next : action.error
       end
     end

--- a/lib/interstate/base/instance_methods.rb
+++ b/lib/interstate/base/instance_methods.rb
@@ -18,10 +18,11 @@ module Interstate
         end
       end
 
-      def ensure_can_transit(event, transition_to, from)
+      def ensure_can_transit(event, transition_to, from, multiple: false)
         @state_machine.evaluate_transition_by!(
           Interactor::Context.new(
-            event: event, transition_to: transition_to, from: from, object: self
+            event: event, transition_to: transition_to, from: from,
+            multiple: multiple, object: self
           )
         )
       end
@@ -36,6 +37,14 @@ module Interstate
 
       def constantize(event)
         Object.const_get(event.to_s.split('_').collect(&:capitalize).join)
+      end
+
+      def interactor_name(event)
+        if state_machine.context.multiple
+          "#{event}_#{state_machine.next_state}"
+        else
+          event
+        end
       end
     end
   end

--- a/lib/interstate/state_machine.rb
+++ b/lib/interstate/state_machine.rb
@@ -13,6 +13,10 @@ module Interstate
       raise failed_transition unless context.from.include? context.object.state.to_sym
     end
 
+    def next_state
+      context.transition_to.first
+    end
+
     def next
       context.object.state = context.transition_to.first
       context.object.save

--- a/spec/models/active_record/vehicle.rb
+++ b/spec/models/active_record/vehicle.rb
@@ -42,7 +42,32 @@ class ShiftUp
 
   def call; end
 end
+class ShiftUpFirstGear
+  include Interactor
+
+  def call; end
+end
+class ShiftUpSecondGear
+  include Interactor
+
+  def call; end
+end
+class ShiftUpThirdGear
+  include Interactor
+
+  def call; end
+end
 class ShiftDown
+  include Interactor
+
+  def call; end
+end
+class ShiftDownFirstGear
+  include Interactor
+
+  def call; end
+end
+class ShiftDownSecondGear
   include Interactor
 
   def call; end

--- a/spec/state_machine_spec.rb
+++ b/spec/state_machine_spec.rb
@@ -29,6 +29,11 @@ RSpec.describe Interstate::StateMachine do
       it 'returns nothing' do
         expect(subject.evaluate_transition_by!(context)).to be_nil
       end
+
+      it 'assigns context' do
+        subject.evaluate_transition_by!(context)
+        expect(subject.context).to eq context
+      end
     end
 
     context 'when transition is not allowed' do


### PR DESCRIPTION
Now an event with multiple transitions has an interactor for every possible
transition. Before this commit the same event could had only a single
interactor.
```ruby
on event: :cycle do |event|
  allow event: event, transition_to: [:proceed], from: [:stop]
  allow event: event, transition_to: [:caution], from: [:proceed]
  allow event: event, transition_to: [:stop], from: [:caution]
end
```
The `cycle` event now call `CycleProceed` and `CycleCaution` interactors. Before this pr all the transition logic and validation were in `Cycle` interactor